### PR TITLE
Bcftools variant call

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -45,5 +45,5 @@ rule all:
         expand(out_alignment_dir_path / "{sample}/{sample}.coverage.per-base.bed.gz", sample=SAMPLES),
         # Variant call:
         expand(varcall_dir_path / (config["assembly"] + ".mpileup.vcf.gz")),
-        expand(varcall_dir_path / (config["assembly"] + ".vcf.gz"))
+        expand(varcall_dir_path / (config["assembly"] + ".vcf.gz")),
         expand(varcall_dir_path / (config["assembly"] + ".filt.vcf.gz"))

--- a/Snakefile
+++ b/Snakefile
@@ -44,5 +44,5 @@ rule all:
         # Mosdepth:
         expand(out_alignment_dir_path / "{sample}/{sample}.coverage.per-base.bed.gz", sample=SAMPLES),
         # Variant call:
-        expand(varcall_dir_path / config["assembly"] + ".mpileup.vcf.gz"),
-        expand(varcall_dir_path / config["assembly"] + ".vcf.gz")
+        expand(varcall_dir_path / (config["assembly"] + ".mpileup.vcf.gz")),
+        expand(varcall_dir_path / (config["assembly"] + ".vcf.gz"))

--- a/Snakefile
+++ b/Snakefile
@@ -13,6 +13,7 @@ assemblies_dir_path = Path(config["assemblies_dir"])
 reads_dir_path = Path(config["reads_dir"])
 # output dirs
 out_alignment_dir_path = Path(config["out_alignment_dir"])
+varcall_dir_path = Path(config["variantcall_dir"])
 # technical dirs
 scripts_dir_path = str(config["scripts_dir"])
 # log dirs
@@ -33,10 +34,15 @@ SAMPLES=config["reads"]
 #### load rules #####
 include: "workflow/rules/Alignment/alignment.smk"
 include: "workflow/rules/Alignment/coverage.smk"
+include: "workflow/rules/VariantCall/Bcftools.smk"
 
 ##### target rules #####
 localrules: all
 
 rule all:
     input:
-        expand(out_alignment_dir_path / "{sample}/{sample}.coverage.per-base.bed.gz", sample=SAMPLES)
+        # Mosdepth:
+        expand(out_alignment_dir_path / "{sample}/{sample}.coverage.per-base.bed.gz", sample=SAMPLES),
+        # Variant call:
+        expand(varcall_dir_path / config["assembly"] + ".mpileup.vcf.gz"),
+        expand(varcall_dir_path / config["assembly"] + ".vcf.gz")

--- a/Snakefile
+++ b/Snakefile
@@ -46,3 +46,4 @@ rule all:
         # Variant call:
         expand(varcall_dir_path / (config["assembly"] + ".mpileup.vcf.gz")),
         expand(varcall_dir_path / (config["assembly"] + ".vcf.gz"))
+        expand(varcall_dir_path / (config["assembly"] + ".filt.vcf.gz"))

--- a/Snakefile
+++ b/Snakefile
@@ -26,6 +26,8 @@ benchmark_dir_path = Path(config["benchmark_dir"])
 
 # SAMPLES = get_scaffolds(reads_dir_path)
 
+if "reads" not in config: # for parse samples IDs from directory
+    config["reads"] = [d.name for d in reads_dir_path.iterdir() if d.is_dir()]
 SAMPLES=config["reads"]
 
 #### load rules #####

--- a/Snakefile
+++ b/Snakefile
@@ -13,7 +13,7 @@ assemblies_dir_path = Path(config["assemblies_dir"])
 reads_dir_path = Path(config["reads_dir"])
 # output dirs
 out_alignment_dir_path = Path(config["out_alignment_dir"])
-varcall_dir_path = Path(config["variantcall_dir"])
+varcall_dir_path = Path(config["varcall_dir"])
 # technical dirs
 scripts_dir_path = str(config["scripts_dir"])
 # log dirs

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -43,12 +43,14 @@ samtools_sort_threads: 7
 samtools_markdup_threads: 3
 index_bam_threads: 30
 mosdepth_threads: 16
+bcftools_varcall_threads: 32
 
 #---- Time ----
 bwa_index_time: "12:00:00"
 bwa_map_time: "24:00:00"
 index_bam_time: "12:00:00"
 mosdepth_time: "12:00:00"
+bcftools_varcall_time: "100:00:00"
 
 #---- Memory ----
 # suppl
@@ -60,3 +62,4 @@ samtools_fixmate_mem_mb: 20000
 samtools_markdup_mem_mb: 20000
 index_bam_mem_mb: 10000
 mosdepth_mem_mb: 10000
+bcftools_varcall_mem_mb: 100000

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -5,6 +5,7 @@ reads_dir: "/mnt/tank/scratch/skliver/common/pinnipeds/pusa_sibirica/male/trimmo
 
 # output dirs
 out_alignment_dir: "data_output/alignment"
+varcall_dir: "data_output/varcall"
 
 # technical dirs
 scripts_dir: "workflow/scripts"
@@ -21,6 +22,13 @@ conda_config: "workflow/envs/conda.yaml"
 reads: ["male_paired_trimmed"] # name of files with reads without suffixes (names should end by _1 for forward, _2 for reverse)
 assembly: "draft_HiC" # name of file with assembly
 min_mapping_quality: 20
+bcftools_mpileup_annotate: "AD,INFO/AD,ADF,INFO/ADF,ADR,INFO/ADR,DP,SP,SCR,INFO/SCR"
+bcftools_call_annotate: "GQ,GP"
+bcftools_mpileup_max_depth: 250
+bcftools_mpileup_min_MQ: 30
+bcftools_mpileup_min_BQ: 30
+bcftools_filter_soft_filter: "LowQual"
+bcftools_filter_exclude: "QUAL < 20.0 || (FORMAT/SP > 60.0 | FORMAT/DP < 5.0 | FORMAT/GQ < 20.0)"
 
 #---- Extensions ----
 assemblies_ext: "fasta"

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -44,6 +44,7 @@ samtools_markdup_threads: 3
 index_bam_threads: 30
 mosdepth_threads: 16
 bcftools_varcall_threads: 32
+bcftools_filter_threads: 10
 
 #---- Time ----
 bwa_index_time: "12:00:00"
@@ -51,6 +52,7 @@ bwa_map_time: "24:00:00"
 index_bam_time: "12:00:00"
 mosdepth_time: "12:00:00"
 bcftools_varcall_time: "100:00:00"
+bcftools_filter_time: "80:00:00"
 
 #---- Memory ----
 # suppl
@@ -63,3 +65,4 @@ samtools_markdup_mem_mb: 20000
 index_bam_mem_mb: 10000
 mosdepth_mem_mb: 10000
 bcftools_varcall_mem_mb: 100000
+bcftools_filter_mem_mb: 40000

--- a/workflow/envs/conda.yaml
+++ b/workflow/envs/conda.yaml
@@ -8,3 +8,4 @@ dependencies:
   - bwa=0.7.17
   - samtools>=1.10
   - mosdepth>=0.3.1
+  - bcftools>=1.12

--- a/workflow/rules/Alignment/alignment.smk
+++ b/workflow/rules/Alignment/alignment.smk
@@ -76,7 +76,7 @@ rule index_bam:
     input:
         rules.bwa_map.output.bam
     output:
-        bai=temp(out_alignment_dir_path / "{sample}/{sample}.sorted.mkdup.bam.bai")
+        bai=out_alignment_dir_path / "{sample}/{sample}.sorted.mkdup.bam.bai"
     log:
         std=log_dir_path / "{sample}/index_bam.log",
         cluster_log=cluster_log_dir_path / "{sample}.index_bam.cluster.log",

--- a/workflow/rules/Alignment/alignment.smk
+++ b/workflow/rules/Alignment/alignment.smk
@@ -46,7 +46,7 @@ rule bwa_map:
         sort_threads=config["samtools_sort_threads"],
         markdup_threads=config["samtools_markdup_threads"],
         per_thread_sort_mem="%sG" % config["bwa_map_per_thread_mem_mb"],
-        prefix=expand(out_alignment_dir_path / "{sample}/{sample}", sample=SAMPLES)
+        prefix=expand(out_alignment_dir_path / "{sample}/{sample}.sorted.mkdup", sample=SAMPLES)
     log:
         bwa_mem=log_dir_path / "{sample}/bwa_mem.log",
         samtools_fixmate=log_dir_path / "{sample}/samtools_fixmate.log",

--- a/workflow/rules/Alignment/alignment.smk
+++ b/workflow/rules/Alignment/alignment.smk
@@ -46,7 +46,7 @@ rule bwa_map:
         sort_threads=config["samtools_sort_threads"],
         markdup_threads=config["samtools_markdup_threads"],
         per_thread_sort_mem="%sG" % config["bwa_map_per_thread_mem_mb"],
-        prefix=expand(out_alignment_dir_path / "{sample}/{sample}.sorted.mkdup", sample=SAMPLES)
+        prefix=lambda wildcards, output: output["bam"][:-4]
     log:
         bwa_mem=log_dir_path / "{sample}/bwa_mem.log",
         samtools_fixmate=log_dir_path / "{sample}/samtools_fixmate.log",

--- a/workflow/rules/Alignment/alignment.smk
+++ b/workflow/rules/Alignment/alignment.smk
@@ -30,8 +30,8 @@ rule bwa_index:
 
 rule bwa_map:
     input:
-        forward_reads=reads_dir_path / ("{sample}_1." + config["reads_ext"] + ".gz"),
-        reverse_reads=reads_dir_path / ("{sample}_2." + config["reads_ext"] + ".gz"),
+        forward_reads=reads_dir_path / "{sample}/{sample}_1." + config["reads_ext"] + ".gz"),
+        reverse_reads=reads_dir_path / "{sample}/{sample}_2." + config["reads_ext"] + ".gz"),
         assembly=rules.bwa_index.output.assembly,
         amb=rules.bwa_index.output.amb,
         ann=rules.bwa_index.output.ann,
@@ -39,7 +39,7 @@ rule bwa_map:
         pac=rules.bwa_index.output.pac,
         sa=rules.bwa_index.output.sa
     output:
-        bam=temp(out_alignment_dir_path / "{sample}/{sample}.sorted.mkdup.bam")
+        bam=out_alignment_dir_path / "{sample}/{sample}.sorted.mkdup.bam"
     params:
         bwa_threads=config["bwa_mem_threads"],
         fixmate_threads=config["samtools_fixmate_threads"],

--- a/workflow/rules/Alignment/alignment.smk
+++ b/workflow/rules/Alignment/alignment.smk
@@ -30,8 +30,8 @@ rule bwa_index:
 
 rule bwa_map:
     input:
-        forward_reads=reads_dir_path / "{sample}/{sample}_1." + config["reads_ext"] + ".gz"),
-        reverse_reads=reads_dir_path / "{sample}/{sample}_2." + config["reads_ext"] + ".gz"),
+        forward_reads=reads_dir_path / ("{sample}/{sample}_1." + config["reads_ext"] + ".gz"),
+        reverse_reads=reads_dir_path / ("{sample}/{sample}_2." + config["reads_ext"] + ".gz"),
         assembly=rules.bwa_index.output.assembly,
         amb=rules.bwa_index.output.amb,
         ann=rules.bwa_index.output.ann,
@@ -89,7 +89,7 @@ rule index_bam:
         cpus=config["index_bam_threads"],
         time=config["index_bam_time"],
         mem=config["index_bam_mem_mb"],
-    threads: 
+    threads:
         config["index_bam_threads"]
     shell:
         "samtools index -@ {threads} {input} > {log.std} 2>&1"

--- a/workflow/rules/Alignment/coverage.smk
+++ b/workflow/rules/Alignment/coverage.smk
@@ -5,7 +5,7 @@ rule mosdepth:
     output:
         out=out_alignment_dir_path / "{sample}/{sample}.coverage.per-base.bed.gz"
     params:
-        pefix=expand(out_alignment_dir_path / "{sample}/{sample}.coverage", sample=SAMPLES),
+        pefix=lambda wildcards, output: output["out"][:-16],
         min_mapping_quality=config["min_mapping_quality"]
     log:
         std=log_dir_path / "{sample}/mosdepth.log",

--- a/workflow/rules/VariantCall/Bcftools.smk
+++ b/workflow/rules/VariantCall/Bcftools.smk
@@ -1,8 +1,8 @@
 rule bcftools_varcall:
     input:
         assembly=rules.bwa_index.output.assembly,
-        samples=expand(out_alignment_dir_path / "{sample}/{sample}.clipped.bam", sample=config["reads"]),
-        indexes=expand(out_alignment_dir_path / "{sample}/{sample}.clipped.bam.bai", sample=config["reads"])
+        samples=expand(out_alignment_dir_path / "{sample}/{sample}.sorted.mkdup.bam", sample=config["reads"]),
+        indexes=expand(out_alignment_dir_path / "{sample}/{sample}.sorted.mkdup.bam.bai", sample=config["reads"])
     output:
         mpileup=varcall_dir_path / (config["assembly"] + ".mpileup.vcf.gz"),
         call=varcall_dir_path / (config["assembly"] + ".vcf.gz")

--- a/workflow/rules/VariantCall/Bcftools.smk
+++ b/workflow/rules/VariantCall/Bcftools.smk
@@ -30,7 +30,7 @@ rule bcftools_varcall:
         config["bcftools_varcall_threads"]
     shell:
         "bcftools mpileup --threads {threads} -d {params.max_depth} -q {params.min_MQ} -Q {params.min_BQ} "
-        "--adjust-MQ {params.adjustMQ} --annotate {params.annotate_mpileup} -Oz -f {input.reference} {input.samples} 2> {log.mpileup} | "
+        "--adjust-MQ {params.adjustMQ} --annotate {params.annotate_mpileup} -Oz -f {input.assembly} {input.samples} 2> {log.mpileup} | "
         "tee {output.mpileup} | bcftools call -Oz -mv --annotate {params.annotate_call} > {output.call} 2> {log.call}"
 
 

--- a/workflow/rules/VariantCall/Bcftools.smk
+++ b/workflow/rules/VariantCall/Bcftools.smk
@@ -38,7 +38,7 @@ rule bcftools_filter:
     input:
         rules.bcftools_varcall.output.call
     output:
-        varcall_dir_path / "{reference_basename}.filt.vcf.gz"
+        varcall_dir_path / (config["assembly"] + ".filt.vcf.gz")
     params:
         soft_filter=config["bcftools_filter_soft_filter"],
         exclude=config["bcftools_filter_exclude"],

--- a/workflow/rules/VariantCall/Bcftools.smk
+++ b/workflow/rules/VariantCall/Bcftools.smk
@@ -4,8 +4,8 @@ rule bcftools_varcall:
         samples=expand(out_alignment_dir_path / "{sample}/{sample}.clipped.bam", sample=config["reads"]),
         indexes=expand(out_alignment_dir_path / "{sample}/{sample}.clipped.bam.bai", sample=config["reads"])
     output:
-        mpileup=varcall_dir_path / config["assembly"] + ".mpileup.vcf.gz",
-        call=varcall_dir_path / config["assembly"] + ".vcf.gz"
+        mpileup=varcall_dir_path / (config["assembly"] + ".mpileup.vcf.gz"),
+        call=varcall_dir_path / (config["assembly"] + ".vcf.gz")
     params:
         adjustMQ=50,
         annotate_mpileup=config["bcftools_mpileup_annotate"],
@@ -14,12 +14,12 @@ rule bcftools_varcall:
         min_MQ=config["bcftools_mpileup_min_MQ"],
         min_BQ=config["bcftools_mpileup_min_BQ"]
     log:
-        mpileup=log_dir_path / config["assembly"] + ".bcftools_mpileup.log",
-        call=log_dir_path / config["assembly"] + ".bcftools_call.log",
-        cluster_log=cluster_log_dir_path / config["assembly"] + ".bcftools_varcall.cluster.log",
-        cluster_err=cluster_log_dir_path / config["assembly"] + ".bcftools_varcall.cluster.err"
+        mpileup=log_dir_path / (config["assembly"] + ".bcftools_mpileup.log"),
+        call=log_dir_path / (config["assembly"] + ".bcftools_call.log"),
+        cluster_log=cluster_log_dir_path / (config["assembly"] + ".bcftools_varcall.cluster.log"),
+        cluster_err=cluster_log_dir_path / (config["assembly"] + ".bcftools_varcall.cluster.err")
     benchmark:
-        benchmark_dir_path / config["assembly"] + ".bcftools_varcall.benchmark.txt"
+        benchmark_dir_path / (config["assembly"] + ".bcftools_varcall.benchmark.txt")
     conda:
         "../../../%s" % config["conda_config"]
     resources:
@@ -43,11 +43,11 @@ rule bcftools_filter:
         soft_filter=config["bcftools_filter_soft_filter"],
         exclude=config["bcftools_filter_exclude"],
     log:
-        std=log_dir_path / config["assembly"] + ".bcftools_filter.log",
-        cluster_log=cluster_log_dir_path / config["assembly"] + ".bcftools_filter.cluster.log",
-        cluster_err=cluster_log_dir_path / config["assembly"] + ".bcftools_filter.cluster.err"
+        std=log_dir_path / (config["assembly"] + ".bcftools_filter.log"),
+        cluster_log=cluster_log_dir_path / (config["assembly"] + ".bcftools_filter.cluster.log"),
+        cluster_err=cluster_log_dir_path / (config["assembly"] + ".bcftools_filter.cluster.err")
     benchmark:
-        benchmark_dir_path / config["assembly"] + ".bcftools_filter.benchmark.txt"
+        benchmark_dir_path / (config["assembly"] + ".bcftools_filter.benchmark.txt")
     conda:
         "../../../%s" % config["conda_config"]
     resources:

--- a/workflow/rules/VariantCall/Bcftools.smk
+++ b/workflow/rules/VariantCall/Bcftools.smk
@@ -1,0 +1,60 @@
+rule bcftools_varcall:
+    input:
+        assembly=rules.bwa_index.output.assembly,
+        samples=expand(out_alignment_dir_path / "{sample}/{sample}.clipped.bam", sample=config["reads"]),
+        indexes=expand(out_alignment_dir_path / "{sample}/{sample}.clipped.bam.bai", sample=config["reads"])
+    output:
+        mpileup=varcall_dir_path / config["assembly"] + ".mpileup.vcf.gz",
+        call=varcall_dir_path / config["assembly"] + ".vcf.gz"
+    params:
+        adjustMQ=50,
+        annotate_mpileup=config["bcftools_mpileup_annotate"],
+        annotate_call=config["bcftools_call_annotate"],
+        max_depth=config["bcftools_mpileup_max_depth"],
+        min_MQ=config["bcftools_mpileup_min_MQ"],
+        min_BQ=config["bcftools_mpileup_min_BQ"]
+    log:
+        mpileup=log_dir_path / config["assembly"] + ".bcftools_mpileup.log",
+        call=log_dir_path / config["assembly"] + ".bcftools_call.log",
+        cluster_log=cluster_log_dir_path / config["assembly"] + ".bcftools_mpileup.cluster.log",
+        cluster_err=cluster_log_dir_path / config["assembly"] + ".bcftools_mpileup.cluster.err"
+    benchmark:
+        benchmark_dir_path / config["assembly"] + ".bcftools_mpileup.benchmark.txt"
+    conda:
+        "../../../%s" % config["conda_config"]
+    resources:
+        cpus=config["bcftools_mpileup_threads"],
+        mem=config["bcftools_mpileup_mem_mb"],
+        time=config["bcftools_mpileup_time"]
+    threads:
+        config["bcftools_mpileup_threads"]
+    shell:
+        "bcftools mpileup --threads {threads} -d {params.max_depth} -q {params.min_MQ} -Q {params.min_BQ} "
+        "--adjust-MQ {params.adjustMQ} --annotate {params.annotate_mpileup} -Oz -f {input.reference} {input.samples} 2> {log.mpileup} | "
+        "tee {output.mpileup} | bcftools call -Oz -mv --annotate {params.annotate_call} > {output.call} 2> {log.call}"
+
+
+rule bcftools_filter:
+    input:
+        rules.bcftools_varcall.output.call
+    output:
+        varcall_dir_path / "{reference_basename}.filt.vcf.gz"
+    params:
+        soft_filter=config["bcftools_filter_soft_filter"],
+        exclude=config["bcftools_filter_exclude"],
+    log:
+        std=log_dir_path / config["assembly"] + ".bcftools_filter.log",
+        cluster_log=cluster_log_dir_path / config["assembly"] + ".bcftools_filter.cluster.log",
+        cluster_err=cluster_log_dir_path / config["assembly"] + ".bcftools_filter.cluster.err"
+    benchmark:
+        benchmark_dir_path / config["assembly"] + ".bcftools_filter.benchmark.txt"
+    conda:
+        "../../../%s" % config["conda_config"]
+    resources:
+        cpus=config["bcftools_filter_threads"],
+        mem=config["bcftools_filter_mem_mb"],
+        time=config["bcftools_filter_time"]
+    threads:
+        config["bcftools_filter_threads"]
+    shell:
+        "bcftools filter -Oz -s {params.soft_filter} --exclude '{params.exclude}' {input} > {output} 2> {log.std}; "

--- a/workflow/rules/VariantCall/Bcftools.smk
+++ b/workflow/rules/VariantCall/Bcftools.smk
@@ -16,18 +16,18 @@ rule bcftools_varcall:
     log:
         mpileup=log_dir_path / config["assembly"] + ".bcftools_mpileup.log",
         call=log_dir_path / config["assembly"] + ".bcftools_call.log",
-        cluster_log=cluster_log_dir_path / config["assembly"] + ".bcftools_mpileup.cluster.log",
-        cluster_err=cluster_log_dir_path / config["assembly"] + ".bcftools_mpileup.cluster.err"
+        cluster_log=cluster_log_dir_path / config["assembly"] + ".bcftools_varcall.cluster.log",
+        cluster_err=cluster_log_dir_path / config["assembly"] + ".bcftools_varcall.cluster.err"
     benchmark:
-        benchmark_dir_path / config["assembly"] + ".bcftools_mpileup.benchmark.txt"
+        benchmark_dir_path / config["assembly"] + ".bcftools_varcall.benchmark.txt"
     conda:
         "../../../%s" % config["conda_config"]
     resources:
-        cpus=config["bcftools_mpileup_threads"],
-        mem=config["bcftools_mpileup_mem_mb"],
-        time=config["bcftools_mpileup_time"]
+        cpus=config["bcftools_varcall_threads"],
+        mem=config["bcftools_varcall_mem_mb"],
+        time=config["bcftools_varcall_time"]
     threads:
-        config["bcftools_mpileup_threads"]
+        config["bcftools_varcall_threads"]
     shell:
         "bcftools mpileup --threads {threads} -d {params.max_depth} -q {params.min_MQ} -Q {params.min_BQ} "
         "--adjust-MQ {params.adjustMQ} --annotate {params.annotate_mpileup} -Oz -f {input.reference} {input.samples} 2> {log.mpileup} | "


### PR DESCRIPTION
1. Added the ability to run a pipeline on multiple samples. Structure example:
└── reads
    ├── sample1
         ├── sample1_1.fastq.gz
         └── sample1_2.fastq.gz
    ├── sample2
         ├── sample2_1.fastq.gz
         └── sample2_2.fastq.gz
2. Added basic implementation of variant calling via Bcftools.